### PR TITLE
Feat: add rel and target attributes to <a> tag in SanityPortableText component

### DIFF
--- a/app/components/sanity/portable-text.tsx
+++ b/app/components/sanity/portable-text.tsx
@@ -36,6 +36,15 @@ export default function PortableText({
       bullet: ({ children }) => <ul className="list-disc">{children}</ul>,
       number: ({ children }) => <ol className="list-decimal">{children}</ol>,
     },
+    marks: {
+      link: ({ children, value }) => {
+        return (
+          <a href={value.href} rel="nofollow" target="_blank">
+            {children}
+          </a>
+        );
+      },
+    },
   };
   return <SanityPortableText value={value} components={components} />;
 }


### PR DESCRIPTION
## Describe your changes

Added rel="nofollow" and target="_blank" to <a> tag in SanityPortableText component

## Issue ticket number and link

Closes #154 

## Details

I used the [existing documentation](https://www.npmjs.com/package/@portabletext/react) to implement requested change.

I verified that links from this (http://localhost:8000/se/blog/sapmi-pride-2024-progamma) blog post 
- are open in a new window locally and
- have new attributes, 
while links on the current version of website (https://garmeres-v2.vercel.app/se/blog/sapmi-pride-2024-progamma) don't have links in question and don't open in a new browser window.

I hope I understood the ticket correctly, @leevi978 . I look forward for your feedback!